### PR TITLE
Use posixpath to avoid Windows backslashes

### DIFF
--- a/apt_repo/__init__.py
+++ b/apt_repo/__init__.py
@@ -5,6 +5,7 @@ import os
 import re
 import urllib.error
 import urllib.request as request
+import posixpath
 
 
 def __download_raw(url):
@@ -217,7 +218,7 @@ class APTRepository:
     @property
     def release_file(self):
         """Returns the Release file of this repository"""
-        url = os.path.join(
+        url = posixpath.join(
             self.__url,
             'dists',
             self.__dist,
@@ -250,7 +251,7 @@ class APTRepository:
         component (str): the component to return packages for
         arch (str): the architecture to return packages for, default: 'amd64'
         """
-        url = os.path.join(
+        url = posixpath.join(
             self.__url,
             'dists',
             self.__dist,
@@ -287,7 +288,7 @@ class APTRepository:
         """
         package = self.get_package(name, version)
 
-        return os.path.join(self.__url, package.filename)
+        return posixpath.join(self.__url, package.filename)
 
     def get_packages_by_name(self, name):
         """


### PR DESCRIPTION
@brennerm - I thought there was a urljoin function somewhere in the standard library! I gave urllib.parse.urljoin a try, but it only joins 2 pieces together. Some searching and experimenting later I still couldn't find a standard library url join function. 

It looks like using posixpath.join however can join all the parts together using just forward slashes so I used this approach rather than the messier replace function in #1