### PR TITLE
switch from urllib to requests

### DIFF
--- a/apt_repo/__init__.py
+++ b/apt_repo/__init__.py
@@ -1,7 +1,6 @@
 import bz2
 import gzip
 import lzma
-import os
 import posixpath
 import re
 import requests

--- a/apt_repo/__init__.py
+++ b/apt_repo/__init__.py
@@ -4,8 +4,7 @@ import lzma
 import os
 import posixpath
 import re
-import urllib.error
-import urllib.request as request
+import requests
 
 
 def __download_raw(url):
@@ -15,7 +14,7 @@ def __download_raw(url):
     # Arguments
     url (str): URL to file
     """
-    return request.urlopen(url).read()
+    return requests.get(url).content
 
 
 def _download(url):
@@ -48,11 +47,11 @@ def _download_compressed(base_url):
         url = base_url + suffix
 
         try:
-            req = request.urlopen(url)
-        except urllib.error.URLError:
+            req = requests.get(url)
+        except requests.error.URLError:
             continue
 
-        return method(req.read()).decode('utf-8')
+        return method(req.content).decode('utf-8')
 
 
 def _get_value(content, key):
@@ -384,3 +383,4 @@ class APTSources:
             packages.extend(repo.get_packages_by_name(name))
 
         return packages
+    

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,6 @@ setup(
     description='Python library to query APT repositories',
     long_description_content_type='text/markdown',
     long_description=long_description,
-    python_requires='>=3.5'
+    python_requires='>=3.5',
+    install_requires=['requests'],
 )


### PR DESCRIPTION
I had a 403 on a package repo.
I started investigating, and switching the libs actually fixes this.

requests seem to be advised to used: https://stackoverflow.com/a/14804320/1548052