### PR TITLE
Add whitespace requirement

### DIFF
--- a/apt_repo/__init__.py
+++ b/apt_repo/__init__.py
@@ -310,7 +310,7 @@ class BinaryPackage:
     @property
     def size(self):
         try:
-            return _get_value(self.__content, 'Size')
+            return _get_value(self.__content, '\sSize')
         except KeyError:
             return None
 


### PR DESCRIPTION
Add whitespace requirement when setting the size-property of a BinaryPackage, in my testing using Ubuntu 22.04 LTS apt repositories (the "main" component) the size-property gets set with the value from Installed-Size in __content.

This change adds a requirement of a white space character in front of the key that circumvents the "wrong" lookup. This introduces a problem when the Size key would be placed first in __content, but from my testing I have not run in to that.